### PR TITLE
Adds theme name output during browse

### DIFF
--- a/browser_guake_theme.sh
+++ b/browser_guake_theme.sh
@@ -7,6 +7,12 @@ total_num=`ls -l $dir | grep -c \.theme`
 cursor=1
 name=`echo $theme_list | awk '{print $'"$cursor"'}'`
 
+function reecho {
+    # replace current line with text output
+    echo -e "\033[1A\033[2K\r$1"
+}
+
+echo ""
 ./guake_theme.sh $name
 
 while [ 1 -eq 1 ] 
@@ -14,18 +20,20 @@ do
     read -sn1  key
     if [ "$key" = "n" ]; then
         if [ $cursor -eq $total_num ]; then 
-            echo "already hit the bottom"
+            reecho "already hit the bottom"
         else
             cursor=$(($cursor + 1)) 
             name=`echo $theme_list | awk '{print $'"$cursor"'}'`
+            reecho "Current theme: $name"
             ./guake_theme.sh $name
         fi
     elif [ "$key" = "p" ]; then
         if [ $cursor -eq 1 ]; then 
-            echo "already hit the top"
+            reecho "already hit the top"
         else
             cursor=$(($cursor - 1))
             name=`echo $theme_list | awk '{print $'"$cursor"'}'`
+            reecho "Current theme: $name"
             ./guake_theme.sh $name
         fi
     elif [ "$key" = "y" ]; then
@@ -34,6 +42,6 @@ do
         echo ""
         exit 0
     else 
-        echo 'press the key among {p, n, y}'
+        reecho 'press the key among {p, n, y}'
     fi
 done


### PR DESCRIPTION
I thought it would be convenient to show the name of the current theme when browsing via the `./browser_guake_theme.sh` script.
![demo_guake](https://user-images.githubusercontent.com/9826865/50794939-80a6b180-1281-11e9-9003-0ce7806390c6.gif)
